### PR TITLE
Implement naive readable hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,12 +469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,7 +701,6 @@ version = "0.1.0"
 dependencies = [
  "cucumber",
  "futures",
- "hex",
  "sha2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 sha2 = "0.10"
-hex = "0.4"
 
 [dev-dependencies]
 cucumber = "0.21"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,37 @@
 use sha2::{Digest, Sha256};
 
-/// Generates a SHA-256 hash and returns it as a hex string.
+/// Syllables used for obfuscating lowercase words.
+pub(crate) const SYLLABLES: [&str; 256] = [
+    "plac", "most", "sam", "ke", "uth", "arl ", "het", "giv", "fa", "first", "own ", "li", "van",
+    "form ", "pres", "ond", "men ", "bef", "old ", "agr", "must", "two", "ight ", "mak", "cons",
+    "nat", "den", "rem", "inst", "eb", "itt", "iss", "tak", "ars", "ap", "app", "iz", "wher", "ec",
+    "mad", "cont", "pe", "such", "lik", "ung", "rec", "gen", "now", "how", "urs", "wa", "ver",
+    "than", "don", "com", "mo", "ught", "pa", "min", "vi", "comm", "sho", "thes", "ents", "then",
+    "aft", "fe", "ek", "ha", "ins", "ep", "ich", "acc", "elf", "ans", "can", "ass", "att", "ni",
+    "ex", "work", "par", "ef", "te", "part ", "ho", "onl", "des", "vo", "tim", "ib", "lo", "has",
+    "tho", "proj", "ert", "gre", "ord", "off ", "stat ", "what", "ort", "der", "eg", "gut", "ach",
+    "art", "si", "ett", "ern", "als", "enb", "bo", "ud", "ys", "them", "som", "mor", "act", "unt",
+    "who", "ac", "ak", "ik", "ish ", "ast", "when", "erg", "po", "ne", "ard", "will", "go", "ugh",
+    "ro", "um", "da", "ens", "ow", "ja", "my", "ind", "ok", "op", "wo", "anc", "ill", "abl",
+    "ther", "fo", "she", "av", "him", "ot", "oth", "ig", "ov", "its", "ell", "wer", "enc", "ma",
+    "man", "di", "od", "end", "do", "up", "re", "no", "im", "le", "ab", "om", "sa", "ul", "ant",
+    "co", "if", "uld", "ist ", "hav", "ons ", "la", "we", "from", "me", "had", "but", "her",
+    "which", "so", "ag", "int", "se", "est", "ol", "os", "qu", "un", "this", "ev", "ect", "ers",
+    "iv", "em", "not", "am", "by", "ess", "und", "ad", "il", "his", "ir", "all", "for", "was",
+    "id", "de", "with", "et", "that", "be", "ut", "ic", "us", "el", "ur", "he", "ent", "as", "or",
+    "al", "ar", "is", "an", "u", "ing", "at", "it", "es", "to", "and", "en", "on", "of", "ed ",
+    "o", "in", "er", "i", "a", "y", "the", "e",
+];
+
+/// Generates a SHA-256 hash and returns it as a syllable string.
 pub fn readable_hash(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
     let result = hasher.finalize();
-    hex::encode(result)
+    result
+        .iter()
+        .map(|b| SYLLABLES[*b as usize])
+        .collect::<String>()
 }
 
 #[cfg(test)]
@@ -14,7 +40,7 @@ mod tests {
 
     #[test]
     fn hashes_consistently() {
-        let expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        let expected = "ungtoattmeertantdipresecorvisuchosfromusellremight itthasissupfeprojthemuthveroff abljahimiz";
         assert_eq!(readable_hash("hello"), expected);
     }
 }

--- a/tests/features/hash.feature
+++ b/tests/features/hash.feature
@@ -2,4 +2,4 @@ Feature: Generate a readable hash
   Scenario: hashing a string
     Given the input "hello"
     When the hash is generated
-    Then the result should be "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    Then the result should be "ungtoattmeertantdipresecorvisuchosfromusellremight itthasissupfeprojthemuthveroff abljahimiz"


### PR DESCRIPTION
## Summary
- map SHA-256 bytes to syllables for readable hashes
- update tests and cucumber feature to expect syllable output
- drop unused hex dependency

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa932c262883308a3fd66f8893667c