### PR TITLE
chore: add release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "readable-hash"
 version = "0.1.0"
 edition = "2024"
+description = "Generate human-readable strings from SHA-256 hashes using syllable mapping"
+readme = "README.md"
+repository = "https://github.com/renatgalimov/readable-hash-rs"
+documentation = "https://docs.rs/readable-hash"
+license = "MIT"
+keywords = ["hash", "sha256", "readable"]
+categories = ["cryptography", "encoding"]
 
 [dependencies]
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -2,4 +2,23 @@
 [![Lint](https://github.com/renatgalimov/readable-hash-rs/actions/workflows/lint.yml/badge.svg)](https://github.com/renatgalimov/readable-hash-rs/actions/workflows/lint.yml)
 
 # readable-hash-rs
-Human-readable hashes for Rust
+Human-readable hashes for Rust.
+
+## Usage
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+readable-hash = "0.1"
+```
+
+Generate a hash:
+
+```rust
+use readable_hash::naive_readable_hash;
+
+fn main() {
+    let hash = naive_readable_hash("hello");
+    println!("{hash}");
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! Generate human-readable strings from SHA-256 hashes.
+
 use sha2::{Digest, Sha256};
 
 /// Syllables used for obfuscating lowercase words.


### PR DESCRIPTION
## Summary
- add crates.io metadata to `Cargo.toml`
- document library usage in `README.md`
- add crate-level docs for `readable_hash`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9b92e4248330b87fe325dfbe9ae3