### PR TITLE
Document naive_readable_hash with doctest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "readable-hash"
 version = "0.1.0"
 edition = "2024"
-description = "Generate human-readable strings from SHA-256 hashes using syllable mapping"
+description = "Generate sentences in a made-up language from SHA-256 hashes using syllable mapping"
 readme = "README.md"
 repository = "https://github.com/renatgalimov/readable-hash-rs"
 documentation = "https://docs.rs/readable-hash"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Lint](https://github.com/renatgalimov/readable-hash-rs/actions/workflows/lint.yml/badge.svg)](https://github.com/renatgalimov/readable-hash-rs/actions/workflows/lint.yml)
 
 # readable-hash-rs
-Human-readable hashes for Rust.
+Human-readable hashes for Rust, producing sentences in a made-up language.
 
 ## Usage
 
@@ -12,13 +12,14 @@ Add the crate to your `Cargo.toml`:
 readable-hash = "0.1"
 ```
 
-Generate a hash:
+Generate a hash sentence:
 
 ```rust
 use readable_hash::naive_readable_hash;
 
 fn main() {
-    let hash = naive_readable_hash("hello");
-    println!("{hash}");
+    let sentence = naive_readable_hash("hello");
+    println!("{sentence}");
+    // ungtoattmeertant dipresecorvisuch osfrom usellremight itthasiss upfeprojthem uthver off abljahim iz
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,19 @@ pub(crate) const SYLLABLES: [&str; 256] = [
     "es", "to", "and ", "en", "on", "of", "ed ", "o", "in", "er", "i", "a", "y", "the ", "e",
 ];
 
-/// Generates a SHA-256 hash and returns it as a syllable string.
+/// Generates a SHA-256 hash and returns it as a sentence in a made-up language.
+///
+/// # Examples
+///
+/// ```rust
+/// use readable_hash::naive_readable_hash;
+///
+/// let sentence = naive_readable_hash("hello");
+/// assert_eq!(
+///     sentence,
+///     "ungtoattmeertant dipresecorvisuch osfrom usellremight itthasiss upfeprojthem uthver off abljahim iz",
+/// );
+/// ```
 pub fn naive_readable_hash(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());


### PR DESCRIPTION
## Summary
- clarify naive_readable_hash produces a sentence in a made-up language
- add doctest example demonstrating the generated sentence for "hello"
- update crate description and README to describe sentence output

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d7fd6a88330a23130dc5c8f0009